### PR TITLE
Fix deprecation warning on lib/devise_security_extension/rails.rb

### DIFF
--- a/lib/devise_security_extension/rails.rb
+++ b/lib/devise_security_extension/rails.rb
@@ -3,10 +3,15 @@ module DeviseSecurityExtension
     ActiveSupport.on_load(:action_controller) do
       include DeviseSecurityExtension::Controllers::Helpers
     end
-    
-    ActionDispatch::Callbacks.to_prepare do
-      DeviseSecurityExtension::Patches.apply
-    end
 
+    if Rails.version > '5'
+      ActiveSupport::Reloader.to_prepare do
+        DeviseSecurityExtension::Patches.apply
+      end
+    else
+      ActionDispatch::Callbacks.to_prepare do
+        DeviseSecurityExtension::Patches.apply
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix following deprecation warning:

```
DEPRECATION WARNING: to_prepare is deprecated and will be removed from Rails 5.1 (use ActiveSupport::Reloader.to_prepare instead) (called from <class:Engine> at /usr/local/bundle/bundler/gems/devise_security_extension-78cd1185e6a8/lib/devise_security_extension/rails.rb:7)
```